### PR TITLE
Fixes #4. Install the geos5 data to etc/MOM5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,3 +202,10 @@ string(REPLACE " " ";" tmp ${FREAL8})
 foreach (flag ${tmp})
   target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
 endforeach ()
+
+install(
+   DIRECTORY data/geos5
+   DESTINATION etc/MOM5
+   USE_SOURCE_PERMISSIONS
+   )
+


### PR DESCRIPTION
With this, in `install` you have:

```tree
install/etc/MOM5/
└── geos5
    ├── 1440x1080
    │   └── INPUT
    │       ├── diag_table
    │       ├── field_table
    │       └── input.nml
    ├── 360x200
    │   └── INPUT
    │       ├── diag_table
    │       ├── field_table
    │       └── input.nml
    ├── 720x410
    │   └── INPUT
    │       ├── diag_table
    │       ├── field_table
    │       └── input.nml
    └── INPUT
        ├── data_table
        ├── diag_table
        ├── field_table
        └── input.nml

8 directories, 13 files
```
