### PR TITLE
Fixes #6. Rename GFDL_fms to fms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES FMS_r8
+  DEPENDENCIES fms_r8
   INCLUDES src/mom5/ocean_param/gotm-4.0/include src/mom5/ocean_core
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES GFDL_fms_r8
+  DEPENDENCIES FMS_r8
   INCLUDES src/mom5/ocean_param/gotm-4.0/include src/mom5/ocean_core
 )
 


### PR DESCRIPTION
Per @aerorahul, renaming FMS. This is 0-diff trivially. 