### PR TITLE
Add netcdf include dir to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ set (SRCS
 esma_add_library (${this}
   SRCS ${SRCS}
   DEPENDENCIES fms_r8
-  INCLUDES src/mom5/ocean_param/gotm-4.0/include src/mom5/ocean_core
+  INCLUDES src/mom5/ocean_param/gotm-4.0/include src/mom5/ocean_core ${INC_NETCDF}
 )
 
 target_compile_definitions (${this} PRIVATE MAPL_MODE EIGHT_BYTE SPMD TIMING use_libMPI use_netCDF USE_OCEAN_BGC)


### PR DESCRIPTION
For some reason, builds on macOS are now wanting an explicit
`${INC_NETCDF}`. Not sure why it is now needed, but possibly due to a
newer CMake on laptop?

Should be zero diff though I'm not sure how to tell.