### PR TITLE
Rename ocean_state_type for GNU build issue

### DIFF
--- a/src/coupler/coupler_main.F90
+++ b/src/coupler/coupler_main.F90
@@ -192,7 +192,7 @@ program coupler_main
   use ice_model_mod,           only: atm_ice_bnd_type_chksum, lnd_ice_bnd_type_chksum
 
   use ocean_model_mod,         only: update_ocean_model, ocean_model_init
-  use ocean_model_mod,         only: ocean_model_end, ocean_public_type, ocean_state_type, ice_ocean_boundary_type
+  use ocean_model_mod,         only: ocean_model_end, ocean_public_type, mom5_ocean_state_type, ice_ocean_boundary_type
   use ocean_model_mod,         only: ocean_model_restart
   use ocean_model_mod,         only: ocean_public_type_chksum, ice_ocn_bnd_type_chksum
 !
@@ -239,7 +239,7 @@ program coupler_main
   type   (ice_data_type) :: Ice
   ! allow members of ocean type to be aliased (ap)
   type (ocean_public_type), target :: Ocean
-  type (ocean_state_type),  pointer :: Ocean_state => NULL()
+  type (mom5_ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type)     :: Atmos_land_boundary
   type(atmos_ice_boundary_type)      :: Atmos_ice_boundary

--- a/src/coupler/flux_exchange.F90
+++ b/src/coupler/flux_exchange.F90
@@ -177,7 +177,7 @@ module flux_exchange_mod
 !DIRECT: same grid, same decomp, direct copy
   use atmos_model_mod, only: atmos_data_type, land_ice_atmos_boundary_type
   use ocean_model_mod, only: ocean_public_type, ice_ocean_boundary_type
-  use ocean_model_mod, only: ocean_state_type
+  use ocean_model_mod, only: mom5_ocean_state_type
   use ice_model_mod,   only: ice_data_type, land_ice_boundary_type, &
        ocean_ice_boundary_type, atmos_ice_boundary_type, Ice_stock_pe, &
        ice_cell_area => cell_area
@@ -511,7 +511,7 @@ subroutine flux_exchange_init ( Time, Atm, Land, Ice, Ocean, Ocean_state,&
   type(land_data_type),              intent(in)  :: Land
   type(ice_data_type),               intent(inout)  :: Ice
   type(ocean_public_type),           intent(inout)  :: Ocean
-  type(ocean_state_type),            pointer        :: Ocean_state
+  type(mom5_ocean_state_type),            pointer        :: Ocean_state
 ! All intent(OUT) derived types with pointer components must be 
 ! COMPLETELY allocated here and in subroutines called from here;
 ! NO pointer components should have been allocated before entry if the
@@ -3112,7 +3112,7 @@ subroutine flux_ocean_to_ice ( Time, Ocean, Ice, Ocean_Ice_Boundary )
     type(atmos_data_type), optional :: Atm
     type(land_data_type), optional  :: Lnd
     type(ice_data_type), optional   :: Ice
-    type(ocean_state_type), optional, pointer :: Ocn_state
+    type(mom5_ocean_state_type), optional, pointer :: Ocn_state
 
     real :: ref_value
     integer :: i, ier
@@ -3178,7 +3178,7 @@ subroutine flux_init_stocks(Time, Atm, Lnd, Ice, Ocn_state)
   type(atmos_data_type) :: Atm
   type(land_data_type)  :: Lnd
   type(ice_data_type)   :: Ice
-  type(ocean_state_type), pointer :: Ocn_state
+  type(mom5_ocean_state_type), pointer :: Ocn_state
 
   integer i, ier
 
@@ -3711,7 +3711,7 @@ end subroutine flux_up_to_atmos
 !		
 !  </TEMPLATE>
   subroutine flux_ocean_from_ice_stocks(ocean_state,Ocean,Ice_Ocean_boundary)
-    type(ocean_state_type),        pointer    :: ocean_state
+    type(mom5_ocean_state_type),        pointer    :: ocean_state
     type(ocean_public_type),       intent(in) :: Ocean
     type(ice_ocean_boundary_type), intent(in) :: Ice_Ocean_Boundary
     real    :: from_dq, cp_ocn

--- a/src/mom5/drivers/ocean_solo.F90
+++ b/src/mom5/drivers/ocean_solo.F90
@@ -122,13 +122,13 @@ program main
   use time_manager_mod,         only: date_to_string
 
   use ocean_model_mod,          only: ocean_model_init , update_ocean_model, ocean_model_end
-  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, ocean_state_type
+  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, mom5_ocean_state_type
   use ocean_types_mod,          only: ice_ocean_boundary_type
 
   implicit none
 
   type (ocean_public_type)               :: Ocean_sfc          
-  type (ocean_state_type),       pointer :: Ocean_state => NULL()
+  type (mom5_ocean_state_type),       pointer :: Ocean_state => NULL()
   type(ice_ocean_boundary_type), target  :: Ice_ocean_boundary 
 
   ! define some time types 

--- a/src/mom5/drivers/ocean_solo_nuopc.inc
+++ b/src/mom5/drivers/ocean_solo_nuopc.inc
@@ -202,7 +202,7 @@ module ocean_solo_mod
   use time_manager_mod,         only: date_to_string
   use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
   use ocean_model_mod,          only: ocean_model_init , update_ocean_model, ocean_model_end
-  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, ocean_state_type
+  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, mom5_ocean_state_type
   use ocean_types_mod,          only: ice_ocean_boundary_type
 
   use ESMF
@@ -220,7 +220,7 @@ module ocean_solo_mod
 
   type ocean_internalstate_type
     type(ocean_public_type),       pointer :: ocean_public_type_ptr
-    type(ocean_state_type),        pointer :: ocean_state_type_ptr
+    type(mom5_ocean_state_type),        pointer :: ocean_state_type_ptr
     type(ice_ocean_boundary_type), pointer :: ice_ocean_boundary_type_ptr
   end type
 
@@ -296,7 +296,7 @@ module ocean_solo_mod
     type(ESMF_VM)      :: vm
     
     type (ocean_public_type),      pointer :: Ocean_sfc          
-    type (ocean_state_type),       pointer :: Ocean_state => NULL()
+    type (mom5_ocean_state_type),       pointer :: Ocean_state => NULL()
     type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary 
 
     ! define some time types 
@@ -758,7 +758,7 @@ module ocean_solo_mod
     type(ESMF_TimeInterval)       :: timeStep
 
     type (ocean_public_type),      pointer :: Ocean_sfc          
-    type (ocean_state_type),       pointer :: Ocean_state
+    type (mom5_ocean_state_type),       pointer :: Ocean_state
     type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary 
 
     ! define some time types 
@@ -905,7 +905,7 @@ module ocean_solo_mod
     
     ! local variables
     type (ocean_public_type),      pointer :: Ocean_sfc          
-    type (ocean_state_type),       pointer :: Ocean_state
+    type (mom5_ocean_state_type),       pointer :: Ocean_state
     type(ocean_internalstate_wrapper)      :: ocean_internalstate
     type(time_type)                        :: Time, Time_restart_current, Time_end
     type(ESMF_Time)                        :: currTime
@@ -1299,7 +1299,7 @@ module esm_mod
   use time_manager_mod,         only: date_to_string
   use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
   use ocean_model_mod,          only: ocean_model_init , update_ocean_model, ocean_model_end
-  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, ocean_state_type
+  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, mom5_ocean_state_type
   use ocean_types_mod,          only: ice_ocean_boundary_type
 
 
@@ -1666,7 +1666,7 @@ program ocean_solo
   use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
 
   use ocean_model_mod,          only: ocean_model_init , update_ocean_model, ocean_model_end
-  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, ocean_state_type
+  use ocean_model_mod,          only: ocean_model_restart, ocean_public_type, mom5_ocean_state_type
   use ocean_types_mod,          only: ice_ocean_boundary_type
 
 

--- a/src/mom5/ocean_core/ocean_model.F90
+++ b/src/mom5/ocean_core/ocean_model.F90
@@ -635,12 +635,12 @@ private
   real :: beta_qf   = 0.0
   real :: beta_lwsw = 0.0
 
-  type, public ::  ocean_state_type; private
+  type, public ::  mom5_ocean_state_type; private
      ! This type is private, and can therefore vary between different ocean models.
      ! All information entire ocean state may be contained here, although it is not
      ! necessary that this is implemented with all models.
      logical       :: is_ocean_pe = .false.       ! .true. on processors that run the ocean model.
-  end type ocean_state_type
+  end type mom5_ocean_state_type
 
   integer :: dt_ocean = -1  ! ocean tracer timestep
 
@@ -670,7 +670,7 @@ contains
 !
 subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)   
     type(ocean_public_type), intent(inout)  :: Ocean
-    type(ocean_state_type),  pointer        :: Ocean_state
+    type(mom5_ocean_state_type),  pointer        :: Ocean_state
     type(time_type),         intent(in)     :: Time_init
     type(time_type),         intent(in)     :: Time_in 
     
@@ -692,7 +692,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
 
     if (associated(Ocean_state)) then
        call mpp_error(WARNING, "ocean_model_init called with an associated "// &
-            "ocean_state_type structure. Model is already initialized.")
+            "mom5_ocean_state_type structure. Model is already initialized.")
        return
     endif
     allocate(Ocean_state)
@@ -1397,7 +1397,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
   subroutine update_ocean_model(Ice_ocean_boundary, Ocean_state, Ocean_sfc, &
                          time_start_update, Ocean_coupling_time_step, do_wave_in)
     type(ice_ocean_boundary_type), intent(inout) :: Ice_ocean_boundary
-    type(ocean_state_type),        pointer       :: Ocean_state
+    type(mom5_ocean_state_type),        pointer       :: Ocean_state
     type(ocean_public_type),       intent(inout) :: Ocean_sfc
     type(time_type),               intent(in)    :: time_start_update
     type(time_type),               intent(in)    :: Ocean_coupling_time_step
@@ -2059,7 +2059,7 @@ subroutine ocean_model_init(Ocean, Ocean_state, Time_init, Time_in)
 ! </SUBROUTINE> NAME="get_ocean_grid_size"
 
 subroutine ocean_model_data3D_get(OS,Ocean, name, array3D,isc,jsc)
-  type(ocean_state_type),     pointer    :: OS
+  type(mom5_ocean_state_type),     pointer    :: OS
   type(ocean_public_type),    intent(in) :: Ocean
   character(len=*)          , intent(in) :: name
   real, dimension(isc:,jsc:,:), intent(out):: array3D
@@ -2078,7 +2078,7 @@ end subroutine ocean_model_data3D_get
 subroutine ocean_model_data2D_get(OS,Ocean, name, array2D,isc,jsc)
   use constants_mod,     only: epsln 
 
-  type(ocean_state_type),     pointer    :: OS
+  type(mom5_ocean_state_type),     pointer    :: OS
   type(ocean_public_type),    intent(in) :: Ocean
   character(len=*)          , intent(in) :: name
   real, dimension(isc:,jsc:), intent(out):: array2D
@@ -2130,7 +2130,7 @@ subroutine ocean_model_data2D_get(OS,Ocean, name, array2D,isc,jsc)
 end subroutine ocean_model_data2D_get
 
 subroutine ocean_model_data1D_get(OS,Ocean, name, value)
-  type(ocean_state_type),     pointer    :: OS
+  type(mom5_ocean_state_type),     pointer    :: OS
   type(ocean_public_type),    intent(in) :: Ocean
   character(len=*)          , intent(in) :: name
   real                      , intent(out):: value
@@ -2178,7 +2178,7 @@ end subroutine ocean_model_data1D_get
 ! </DESCRIPTION>
 !
   subroutine ocean_model_init_sfc(Ocean_state, Ocean)
-    type(ocean_state_type),  pointer       :: Ocean_state    
+    type(mom5_ocean_state_type),  pointer       :: Ocean_state    
     type(ocean_public_type), intent(inout) :: Ocean
 
     call ocean_tpm_init_sfc(Domain, T_prog(:), Dens, Ocean, Time, Grid)
@@ -2200,7 +2200,7 @@ end subroutine ocean_model_data1D_get
 ! </DESCRIPTION>
 !
   subroutine ocean_model_flux_init(Ocean_state)
-    type(ocean_state_type), pointer       :: Ocean_state
+    type(mom5_ocean_state_type), pointer       :: Ocean_state
     
     call ocean_tpm_flux_init
     
@@ -2220,14 +2220,14 @@ end subroutine ocean_model_data1D_get
 !
 ! NOTE from nnz: This module keeps its own Time and does not need the Time_in argument.
 ! Arguments: 
-!   Ocean_state (type(ocean_state_type), pointer) - A structure containing the internal ocean state.
+!   Ocean_state (type(mom5_ocean_state_type), pointer) - A structure containing the internal ocean state.
 !   Time_in     (type(time_type), intent(in))     - The model time, used for writing restarts.
 !   Ocean_sfc   (type(ocean_public_type), optional, intent(inout))- An ocean_public_type structure that is to be
 !                   deallocated upon termination.
 ! </DESCRIPTION>
 !
   subroutine ocean_model_end(Ocean_sfc, Ocean_state, Time_in)
-    type(ocean_state_type),            pointer       :: Ocean_state
+    type(mom5_ocean_state_type),            pointer       :: Ocean_state
     type(time_type),                   intent(in)    :: Time_in
     type(ocean_public_type), optional, intent(inout) :: Ocean_sfc
 
@@ -2383,7 +2383,7 @@ end subroutine ocean_model_data1D_get
 ! </DESCRIPTION>
 !
   subroutine ocean_model_restart(Ocean_state, timestamp)
-     type(ocean_state_type),    pointer     :: Ocean_state
+     type(mom5_ocean_state_type),    pointer     :: Ocean_state
      character(len=*), intent(in), optional :: timestamp
 
      call ocean_tracer_restart(Time, T_prog, timestamp)
@@ -2421,7 +2421,7 @@ end subroutine ocean_model_data1D_get
 ! </DESCRIPTION>
 !
 subroutine ocean_stock_pe(Ocean_state, index, value, time_index)
-  type(ocean_state_type),pointer     :: Ocean_state
+  type(mom5_ocean_state_type),pointer     :: Ocean_state
   integer,               intent(in)  :: index
   real,                  intent(out) :: value
   integer, optional,     intent(in)  :: time_index ! -1=previous, 0=now, or +1=next


### PR DESCRIPTION
Kind of ugly hack-workaround to help fix issue https://github.com/GEOS-ESM/GEOSgcm/issues/177. Rename `ocean_state_type` in MOM5 to `mom5_ocean_state_type`.

Currently testing with Intel to make sure it is benign.