### PR TITLE
Fix in configuration

### DIFF
--- a/data/geos5/1440x1080/INPUT/diag_table
+++ b/data/geos5/1440x1080/INPUT/diag_table
@@ -1,5 +1,5 @@
 CM2.1p1
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #output files
 #"atmos_daily",   24,  "hours",  1, "days", "time",
 #"atmos_8xdaily",  3,  "hours",  1, "days", "time",

--- a/data/geos5/1440x1080/INPUT/input.nml
+++ b/data/geos5/1440x1080/INPUT/input.nml
@@ -342,18 +342,18 @@
 	use_this_module=.true.
 	debug_this_module=.false.
 	river_insertion_thickness=40.0
-	river_diffusion_thickness=40.0
-	river_diffusivity=5.e-2
-	river_diffuse_salt=.true.
-	river_diffuse_temp=.true.
+	river_diffusion_thickness=0.0      
+	river_diffusivity=0.0
+	river_diffuse_salt=.false.
+	river_diffuse_temp=.false.
 /
 
  &ocean_riverspread_nml
 	use_this_module=.true.
 	debug_this_module=.false
 	riverspread_diffusion=.true.
-	riverspread_diffusion_passes=500
-	vel_micom_smooth=2.0
+	riverspread_diffusion_passes=2
+	vel_micom_smooth=0.2
 /
 
  &ocean_rough_nml
@@ -569,10 +569,6 @@
 /
 
  &ocean_vert_kpp_mom4p1_nml
-	 use_this_module=.true.
-/
-
- &ocean_vert_kpp_nml
 	use_this_module=.true.
 	diff_cbt_iw=0.0
 	visc_cbu_iw=0.0

--- a/data/geos5/360x200/INPUT/diag_table
+++ b/data/geos5/360x200/INPUT/diag_table
@@ -1,5 +1,5 @@
 CM2.1p1
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #output files
 #"atmos_daily",   24,  "hours",  1, "days", "time",
 #"atmos_8xdaily",  3,  "hours",  1, "days", "time",

--- a/data/geos5/720x410/INPUT/diag_table
+++ b/data/geos5/720x410/INPUT/diag_table
@@ -1,5 +1,5 @@
 CM2.1p1
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #output files
 #"atmos_daily",   24,  "hours",  1, "days", "time",
 #"atmos_8xdaily",  3,  "hours",  1, "days", "time",

--- a/data/geos5/INPUT/diag_table
+++ b/data/geos5/INPUT/diag_table
@@ -1,5 +1,5 @@
 CM2.1p1
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #output files
 #"atmos_daily",   24,  "hours",  1, "days", "time",
 #"atmos_8xdaily",  3,  "hours",  1, "days", "time",


### PR DESCRIPTION
This PR fixes two issues in MOM5 configuration:

- River spread bug in 1/4 degree setup
- Changes reference year in diag_table to 1900, to make different netcdf tools stop complaining about time scale in MOM diagnostic files.

