### PR TITLE
Update Intel flags for MOM5 to avoid warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ esma_add_library (${this}
 target_compile_definitions (${this} PRIVATE MAPL_MODE EIGHT_BYTE SPMD TIMING use_libMPI use_netCDF USE_OCEAN_BGC)
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
-   set(CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_Release_Flags} ${common_Fortran_Flags} -stack_temps -safe_cray_ptr -assume byterecl -fp-model precise -fp-model source -ftz -align all -fno-alias -align dcommons ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
+   set(CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_Release_Flags} ${common_Fortran_Flags} -stack-temps -safe-cray-ptr -assume byterecl -fp-model precise -fp-model source -ftz -align all -fno-alias -align dcommons ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
 endif ()
 
 


### PR DESCRIPTION
Builds of MOM5 using Intel 2021 throw warnings:
```
ifort: command line warning #10434: option '-stack_temps' use with underscore is deprecated; use '-stack-temps' instead
ifort: command line warning #10434: option '-safe_cray_ptr' use with underscore is deprecated; use '-safe-cray-ptr' instead
```
So, to remove this warning, we change the flags from underscore to hyphen