### PR TITLE
Update FMS CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES fms_r8
+  DEPENDENCIES FMS::fms_r8
   INCLUDES 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mom5/ocean_param/gotm-4.0/include> 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mom5/ocean_core>


### PR DESCRIPTION
As we move to FMS in Baselibs, we shouldn't use the old `fms_r4` and `fms_r8` targets anymore as they are non-standard. Instead we move to `FMS::fms_r4` and `FMS::fms_r8`.